### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,17 +13,17 @@
       "runs-on": "ubuntu-latest",
       "steps": [
         {
-          "uses": "actions/checkout@v3.3.0"
+          "uses": "actions/checkout@v4.2.2"
         },
         {
           "run": "./.pages.sh"
         },
         {
-          "uses": "actions/upload-pages-artifact@v1.0.7"
+          "uses": "actions/upload-pages-artifact@v3.0.1"
         },
         {
           "id": "deployment",
-          "uses": "actions/deploy-pages@v1.2.3"
+          "uses": "actions/deploy-pages@v4.0.5"
         }
       ]
     },
@@ -36,13 +36,13 @@
       "runs-on": "ubuntu-latest",
       "steps": [
         {
-          "uses": "actions/checkout@v3.3.0"
+          "uses": "actions/checkout@v4.2.2"
         },
         {
           "run": "./.pages.sh"
         },
         {
-          "uses": "actions/upload-pages-artifact@v1.0.7"
+          "uses": "actions/upload-pages-artifact@v3.0.1"
         }
       ]
     }

--- a/.github/workflows/gha-update.yml
+++ b/.github/workflows/gha-update.yml
@@ -4,13 +4,13 @@
       "runs-on": "ubuntu-latest",
       "steps": [
         {
-          "uses": "actions/checkout@v3.3.0",
+          "uses": "actions/checkout@v4.2.2",
           "with": {
             "token": "${{ secrets.WORKFLOW_SECRET }}"
           }
         },
         {
-          "uses": "saadmk11/github-actions-version-updater@v0.7.3",
+          "uses": "saadmk11/github-actions-version-updater@v0.8.1",
           "with": {
             "pull_request_user_reviewers": "mirabilos",
             "token": "${{ secrets.WORKFLOW_SECRET }}"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-pages-artifact](https://github.com/actions/upload-pages-artifact)** published a new release **[v3.0.1](https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.1)** on 2024-02-07T06:59:16Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.1)** on 2023-08-13T13:53:59Z
* **[actions/deploy-pages](https://github.com/actions/deploy-pages)** published a new release **[v4.0.5](https://github.com/actions/deploy-pages/releases/tag/v4.0.5)** on 2024-03-18T15:43:13Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
